### PR TITLE
Fixed bug in {} monad looping

### DIFF
--- a/brain_flak.rb
+++ b/brain_flak.rb
@@ -52,7 +52,7 @@ def read_until_stack_end(s, start)
     when '}' then
       stack_height -= 1
       if stack_height == -1 then
-        return i
+        return i + start + 1
       end
     end
   end


### PR DESCRIPTION
Since the program loops through a subarray in this function the indexing gets offset and needs to be fixed before it gets returned.
