### PR TITLE
Completed Debug Flags

### DIFF
--- a/Interpreter.rb
+++ b/Interpreter.rb
@@ -31,7 +31,7 @@ class BrainFlakInterpreter
   attr_reader :active_stack, :running
 
   def initialize(source, args, debug)
-  	# Strips the source of any characters that aren't brackets or part of debug flags
+    # Strips the source of any characters that aren't brackets or part of debug flags
     @source = source.gsub(/(?:(?<=[()\[\]{}<>])|\s|^)[^#()\[\]{}<>]+/, "")
     @left = Stack.new('Left')
     @right = Stack.new('Right')
@@ -77,7 +77,9 @@ class BrainFlakInterpreter
       print "#" + flag.to_s + " "
       case flag
         when :dv then puts @current_value
-        when :dc then puts @active_stack.inspect_array
+        when :dc then
+          print @active_stack == @left ? "(left) " : "(right) "
+          puts @active_stack.inspect_array
         when :dl then puts @left.inspect_array
         when :dr then puts @right.inspect_array
       end

--- a/Interpreter.rb
+++ b/Interpreter.rb
@@ -31,7 +31,8 @@ class BrainFlakInterpreter
   attr_reader :active_stack, :running
 
   def initialize(source, args, debug)
-    @source = source
+  	# Strips the source of any characters that aren't brackets or part of debug flags
+    @source = source.gsub(/(?:(?<=[()\[\]{}<>])|\s|^)[^#()\[\]{}<>]+/, "")
     @left = Stack.new('Left')
     @right = Stack.new('Right')
     @main_stack = []

--- a/Interpreter.rb
+++ b/Interpreter.rb
@@ -39,6 +39,8 @@ class BrainFlakInterpreter
     @index = 0
     @current_value = 0
     @running = @source.length > 0
+    # Hash.new([]) does not work since modifications change that original array
+    @debug_flags = Hash.new{|h,k| h[k] = []} if debug
     args.each do|a|
       if a =~ /\d+/
         @active_stack.push(a.to_i)
@@ -51,18 +53,18 @@ class BrainFlakInterpreter
 
   def remove_debug_flags(debug)
     while match = /#[^#()\[\]{}<>]*/.match(@source) do
-      str = @souce.slice!(m.begin(0)..m.end(0)-1)
+      str = @source.slice!(match.begin(0)..match.end(0)-1)
 
       if debug then
         case str
           when "#dv"
-            # do something
+            @debug_flags[match.begin(0)] = @debug_flags[match.begin(0)].push(:dv)
           when "#dc"
-            # do something
+            @debug_flags[match.begin(0)] = @debug_flags[match.begin(0)].push(:dc)
           when "#dl"
-            # do something
+            @debug_flags[match.begin(0)] = @debug_flags[match.begin(0)].push(:dl)
           when "#dr"
-            # do something
+            @debug_flags[match.begin(0)] = @debug_flags[match.begin(0)].push(:dr)
         end
       end
     end

--- a/Interpreter.rb
+++ b/Interpreter.rb
@@ -41,7 +41,7 @@ class BrainFlakInterpreter
     @current_value = 0
     @running = @source.length > 0
     # Hash.new([]) does not work since modifications change that original array
-    @debug_flags = Hash.new{|h,k| h[k] = []} if debug
+    @debug_flags = Hash.new{|h,k| h[k] = []}
     @last_op = :none
     args.each do|a|
       if a =~ /\d+/

--- a/Interpreter.rb
+++ b/Interpreter.rb
@@ -54,7 +54,7 @@ class BrainFlakInterpreter
   end
 
   def remove_debug_flags(debug)
-    while match = /#[^#()\[\]{}<>]*/.match(@source) do
+    while match = /#[^#()\[\]{}<>\s]*/.match(@source) do
       str = @source.slice!(match.begin(0)..match.end(0)-1)
 
       if debug then

--- a/Interpreter.rb
+++ b/Interpreter.rb
@@ -30,7 +30,7 @@ class BrainFlakInterpreter
 
   attr_reader :active_stack, :running
 
-  def initialize(source, args)
+  def initialize(source, args, debug)
     @source = source
     @left = Stack.new('Left')
     @right = Stack.new('Right')
@@ -44,6 +44,26 @@ class BrainFlakInterpreter
         @active_stack.push(a.to_i)
       else
         raise BrainFlakError.new("Invalid integer in input", 0)
+      end
+    end
+    remove_debug_flags(debug)
+  end
+
+  def remove_debug_flags(debug)
+    while match = /#[^#()\[\]{}<>]*/.match(@source) do
+      str = @souce.slice!(m.begin(0)..m.end(0)-1)
+
+      if debug then
+        case str
+          when "#dv"
+            # do something
+          when "#dc"
+            # do something
+          when "#dl"
+            # do something
+          when "#dr"
+            # do something
+        end
       end
     end
   end

--- a/brain_flak.rb
+++ b/brain_flak.rb
@@ -1,20 +1,52 @@
 require './stack.rb'
 require './Interpreter.rb'
 
+require 'optparse'
+
+debug = false
+arg_path = ""
+
+parser = OptionParser.new do |opts|
+  # This needs updating
+  opts.banner = "Welcome to Brain-Flak!"\
+                "\nUsage:"\
+                "brain_flak source_file"\
+                "brain_flak source_file args\n"
+
+  opts.on("-d", "--debug", "Enables parsing of debug commands") do
+    debug = true
+  end
+
+  opts.on("-f", "--argument-file=FILE", "Reads arguments for the brain-flak program from FILE and ignores those provided as command line arguments") do |file|
+    arg_path = file
+  end
+end
+
+begin
+  parser.order!
+rescue OptionParser::ParseError => e
+  puts e
+  puts "\n"
+  puts parser
+  exit
+end
+# parser.order! removes all the option flags from ARGV
+# so all is left is the brain-flak file and the arguments
 if ARGV.length < 1 then
-  puts "Welcome to Brain-Flak!"\
-       "\nUsage:"\
-       "brain_flak source_file"\
-       "brain_flak source_file args\n"
+  puts parser
   exit
 end
 
 source_path = ARGV[0]
-if ARGV[1] == '-f'
-  input_file = File.open(ARGV[2], 'r')
+if arg_path != "" then
+  input_file = File.open(arg_path, 'r')
   numbers = input_file.read.gsub(/\s+/m, ' ').strip.split(" ")
-elsif
+else
   numbers = ARGV[1..-1]
+end
+
+if debug then
+  puts "Debug mode... ENGAGED!"
 end
 
 source_file = File.open(source_path, 'r')

--- a/brain_flak.rb
+++ b/brain_flak.rb
@@ -53,7 +53,7 @@ source_file = File.open(source_path, 'r')
 source = source_file.read
 source_length = source.length
 
-interpreter = BrainFlakInterpreter.new(source, numbers)
+interpreter = BrainFlakInterpreter.new(source, numbers, debug)
 
 begin
   while interpreter.running do

--- a/stack.rb
+++ b/stack.rb
@@ -29,6 +29,10 @@ class Stack
   def talk
     puts @name
   end
+
+  def inspect_array
+    return @data.inspect
+  end
 end
 
 def is_opening_bracket?(b)


### PR DESCRIPTION
There now exist four debug flags that do stuff when the brain flak program in which they appear is run by the interpreter with the -d or --debug flag (otherwise they are ignored). This resolves issue #6 
- #dv prints the current value
- #dc prints which stack is the current stack (left or right) and its contents
- #dl prints the contents of the left stack
- #dr prints the contents of the right stack

Fixes a bug where nilads containing nonbracket characters that weren't part of debug flags would behave as monads with no contents.

The program now uses optparse for handling command line options
