### PR TITLE
Version 1.3.0

### DIFF
--- a/BrainFlakError.rb
+++ b/BrainFlakError.rb
@@ -1,0 +1,10 @@
+class BrainFlakError < StandardError
+
+  attr_reader :cause, :pos
+
+  def initialize(cause, pos)
+    @cause = cause
+    @pos = pos
+    super("Error at character %d: %s" % [pos, cause])
+  end
+end

--- a/Interpreter.rb
+++ b/Interpreter.rb
@@ -89,22 +89,18 @@ class BrainFlakInterpreter
         when "dv" then STDERR.puts @current_value
         when "av" then STDERR.puts (@current_value%256).chr(Encoding::UTF_8)
         when "uv" then STDERR.puts (@current_value%2**32).chr(Encoding::UTF_8)
-        when "dc","ac","uc" then
+        when "dc","ac" then
           print @active_stack == @left ? "(left) " : "(right) "
           case flag.to_s
             when "dc" then
               STDERR.puts @active_stack.inspect_array
             when "ac" then
-              STDERR.puts @active_stack.char_inspect_array(256)
-            when "uc" then
               STDERR.puts @active_stack.char_inspect_array(2**32)
           end
         when "dl" then STDERR.puts @left.inspect_array
-        when "al" then STDERR.puts @left.char_inspect_array(256)
-        when "ul" then STDERR.puts @left.char_inspect_array(2**32)
+        when "al" then STDERR.puts @left.char_inspect_array(2**32)
         when "dr" then STDERR.puts @right.inspect_array
-        when "ar" then STDERR.puts @right.char_inspect_array(256)
-        when "ur" then STDERR.puts @right.char_inspect_array(2**32)
+        when "ar" then STDERR.puts @right.char_inspect_array(2**32)
         when "df" then
           builder = ""
           if @left.height > 0 then
@@ -121,11 +117,8 @@ class BrainFlakInterpreter
             builder += " "*(max_left+1) + "^\n"
           end
           STDERR.puts builder
-        when "af","uf" then
-          case flag.to_s
-            when "af" then limit=256
-            when "uf" then limit=2**32
-          end
+        when "af" then
+          limit=2**32
           builder = @active_stack == @left ? "^\n" : "  ^\n"
           for i in 0..[@left.height,@right.height].max do
             c_right = (@right.at(i) != nil ? @right.at(i) : 32)%limit
@@ -174,7 +167,7 @@ class BrainFlakInterpreter
         #Clear the stack to prevent error
         @main_stack = []
         #Add a newline for formatting
-        puts
+        STDERR.puts
       end
       STDERR.flush
     end

--- a/Interpreter.rb
+++ b/Interpreter.rb
@@ -145,7 +145,7 @@ class BrainFlakInterpreter
            end
            if sub_interpreter.main_stack.length > 0
             unmatched_brak = sub_interpreter.main_stack[0]
-            raise BrainFlakError.new("Unclosed '%s' character." % unmatched_brak[0], unmatched_brak[2])
+            raise BrainFlakError.new("Unmatched '%s' character." % unmatched_brak[0], unmatched_brak[2] + 1)
            end
          rescue Interrupt
            STDERR.puts "\nKeyboard Interrupt"
@@ -200,7 +200,7 @@ class BrainFlakInterpreter
       if is_opening_bracket?(current_symbol) then
         if current_symbol == '{' and @active_stack.peek == 0 then
           new_index = read_until_matching(@source, @index)
-          raise BrainFlakError.new("Unmatched {", @index + 1) if new_index == nil
+          raise BrainFlakError.new("Unmatched '{' character", @index + 1) if new_index == nil
           @index = new_index
         else
           @main_stack.push([current_symbol, @current_value, @index])
@@ -209,8 +209,9 @@ class BrainFlakInterpreter
 
       elsif is_closing_bracket?(current_symbol) then
         data = @main_stack.pop
-        raise BrainFlakError.new("Unmatched " + current_symbol, @index + 1) if data == nil
-        raise BrainFlakError.new("Mismatched closing bracket %s. Expected to close %s at character %d" % [current_symbol, data[0], data[2] + 1], @index + 1) if not brackets_match?(data[0], current_symbol)
+        raise BrainFlakError.new("Unmatched '" + current_symbol + "' character", @index + 1) if data == nil
+        #Here I use @source[@index] I am not sure why but @current symbol always yields nothing
+        raise BrainFlakError.new("Expected to close '%s' from location %d but instead encountered '%s' " % [data[0] , data[2] + 1, @source[@index]], @index + 1) if not brackets_match?(data[0], current_symbol)
 
         case current_symbol
           when ')' then @active_stack.push(@current_value)

--- a/Interpreter.rb
+++ b/Interpreter.rb
@@ -1,17 +1,7 @@
 require 'io/console'
 require_relative './stack.rb'
 require_relative './Flag.rb'
-
-class BrainFlakError < StandardError
-
-  attr_reader :cause, :pos
-
-  def initialize(cause, pos)
-    @cause = cause
-    @pos = pos
-    super("Error at character %d: %s" % [pos, cause])
-  end
-end
+require_relative './BrainFlakError.rb'
 
 def read_until_matching(s, start)
   stack_height = 0

--- a/Interpreter.rb
+++ b/Interpreter.rb
@@ -166,8 +166,8 @@ class BrainFlakInterpreter
         print "\n"
         @current_value += flag.get_data
       when "pu" then
-	#Take input
-        garbage = gets.chomp
+        #Take input
+        $stdin.gets
       when "ex" then
         #Exit program
         @running = false

--- a/Interpreter.rb
+++ b/Interpreter.rb
@@ -165,6 +165,16 @@ class BrainFlakInterpreter
       when "lt" then 
         print "\n"
         @current_value += flag.get_data
+      when "pu" then
+	#Take input
+        garbage = gets.chomp
+      when "ex" then
+        #Exit program
+        @running = false
+        #Clear the stack to prevent error
+        @main_stack = []
+        #Add a newline for formatting
+        puts
       end
       STDERR.flush
     end

--- a/brain_flak.rb
+++ b/brain_flak.rb
@@ -6,6 +6,8 @@ VERSION_STRING =  "Brain-Flak Ruby Interpreter v1.2.0"
 require 'optparse'
 
 debug = false
+do_in = true
+do_out = false
 ascii_in = false
 ascii_out = false
 reverse = false
@@ -39,6 +41,14 @@ parser = OptionParser.new do |opts|
     ascii_out = true
   end
 
+  opts.on("-n","--no-in", "Input is ignored") do
+    do_in = false
+  end
+
+  opts.on("-N","--no-out", "No output is produced.  Debug flags and error messages still appear") do
+    do_out = false
+  end
+
   opts.on("-r", "--reverse", "Reverses the order that arguments are pushed onto the stack AND that values are printed at the end.") do
     reverse = true
   end
@@ -69,14 +79,18 @@ if ARGV.length < 1 then
 end
 
 source_path = ARGV[0]
-if arg_path != "" then
+#No input
+if !do_in then
+  numbers = []
+#Input from file
+elsif arg_path != "" then
   input_file = File.open(arg_path, 'r:UTF-8')
   if !ascii_in
     numbers = input_file.read.gsub(/\s+/m, ' ').strip.split(" ")
   else
     numbers = input_file.read.split("")
   end
-
+#Input from command line
 else
   if ascii_in
     numbers = ARGV[1..-1].join(" ").split("")
@@ -111,7 +125,9 @@ begin
     unmatched_brak = interpreter.main_stack[0]
     raise BrainFlakError.new("Unmatched '%s' character." % unmatched_brak[0], unmatched_brak[2] + 1)
   end
-  interpreter.active_stack.print_stack(ascii_out, reverse)
+  if do_out then
+    interpreter.active_stack.print_stack(ascii_out, reverse)
+  end
 
 rescue BrainFlakError => e
   STDERR.puts e.message

--- a/brain_flak.rb
+++ b/brain_flak.rb
@@ -7,7 +7,7 @@ require 'optparse'
 
 debug = false
 do_in = true
-do_out = false
+do_out = true
 ascii_in = false
 ascii_out = false
 reverse = false

--- a/brain_flak.rb
+++ b/brain_flak.rb
@@ -22,7 +22,28 @@ parser = OptionParser.new do |opts|
     debug = true
   end
 
+  opts.on("-H", "--help-debug", "Prints a list of debug flags and what they do") do
+    flag_desc= [
+      ["ac","Prints the current stack as ASCII characters"],
+      ["al","Prints the left stack as ASCII characters"],
+      ["av","Prints the current value of the scope as an ASCII character"],
+      ["ar","Prints the right stack as ASCII characters"],
+      ["cy","Prints the number of elapsed cycles"],
+      ["dc","Prints the current stack in decimal"],
+      ["dl","Prints the left stack in decimal"],
+      ["dv","Prints the current value of the scope in decimal"],
+      ["dr","Prints the right stack in decimal"],
+      ["ex","Terminates the program"],
+      ["ij","Pauses program and prompts user for Brain-Flak code to be run in place of the flag"],
+      ["pu","Pauses the program until the user hits the return key"],
+    ]    
+    flag_desc.each do | flag |
+      puts "   "+flag[0]+":       "+flag[1]
+    end
+  end
+
   opts.on("-f", "--file=FILE", "Reads input for the brain-flak program from FILE, rather than from the command line.") do |file|
+    puts file
     arg_path = file
   end
 

--- a/brain_flak.rb
+++ b/brain_flak.rb
@@ -38,7 +38,7 @@ parser = OptionParser.new do |opts|
       ["pu","Pauses the program until the user hits the return key"],
     ]    
     flag_desc.each do | flag |
-      puts "   "+flag[0]+":       "+flag[1]
+      STDERR.puts "   "+flag[0]+":       "+flag[1]
     end
   end
 

--- a/brain_flak.rb
+++ b/brain_flak.rb
@@ -109,7 +109,7 @@ begin
   end
   if interpreter.main_stack.length > 0
     unmatched_brak = interpreter.main_stack[0]
-    raise BrainFlakError.new("Unclosed '%s' character." % unmatched_brak[0], unmatched_brak[2])
+    raise BrainFlakError.new("Unmatched '%s' character." % unmatched_brak[0], unmatched_brak[2] + 1)
   end
   interpreter.active_stack.print_stack(ascii_out, reverse)
 

--- a/brain_flak.rb
+++ b/brain_flak.rb
@@ -1,7 +1,7 @@
 require_relative './stack.rb'
 require_relative './Interpreter.rb'
 
-VERSION_STRING =  "Brain-Flak Ruby Interpreter v1.2.0"
+VERSION_STRING =  "Brain-Flak Ruby Interpreter v1.2.0-dev"
 
 require 'optparse'
 

--- a/brain_flak.rb
+++ b/brain_flak.rb
@@ -1,7 +1,7 @@
 require_relative './stack.rb'
 require_relative './Interpreter.rb'
 
-VERSION_STRING =  "Brain-Flak Ruby Interpreter v1.2.0-dev"
+VERSION_STRING =  "Brain-Flak Ruby Interpreter v1.3.0"
 
 require 'optparse'
 

--- a/stack.rb
+++ b/stack.rb
@@ -1,3 +1,5 @@
+require_relative './BrainFlakError.rb'
+
 class Stack
   def initialize(name)
     @name = name
@@ -25,7 +27,12 @@ class Stack
   def print_stack(ascii_mode, reverse)
     (reverse ? @data: @data.reverse).each do |value|
       if ascii_mode
-        print (value % 2 ** 32).chr(Encoding::UTF_8)
+        begin
+          print (value % 2 ** 32).chr(Encoding::UTF_8)
+        rescue RangeError => ex
+          #Error at character 0 is probably not right but I can't access the proper location from here
+          raise BrainFlakError.new("Value #{value} is out of range for UTF_8 encoding.",0)
+        end
       else
         print value.to_s + "\n"
       end


### PR DESCRIPTION
Changes to debug flags and command line arguments

 * Consolidated UTF-8 and ASCII debug flags

 * Added `@pu` flag to pause execution

 * Added `@ex` flag to end execution

 * Added `-H` command line argument to help with debug flags

 *  Added `-N` and `-n` flags to suppress output and input respectively

 * Errors now give consistent line numbers

 * Removed UTF out of range ruby errors and replaced them with more helpful Brain-Flak errors