### PR TITLE
Interpreter.inspect now works again

### DIFF
--- a/Interpreter.rb
+++ b/Interpreter.rb
@@ -247,11 +247,11 @@ class BrainFlakInterpreter
     index = @index
     offset = 0
     @debug_flags.each_pair do |k,v|
-      v.each do |sym|
-        source.insert(k + offset, "#%s" % sym.id2name);
-        offset += sym.id2name.length + 1
+      v.each do |flag|
+        source.insert(k + offset, "@%s" % flag.to_s);
+        offset += flag.to_s.length + 1
         if k <= index then
-          index += sym.id2name.length + 1
+          index += flag.to_s.length + 1
         end
       end
     end


### PR DESCRIPTION
Inspect hadn't been updated when the debug flags were changed from symbols and was trying to call a method that the new DebugFlag object didn't have.